### PR TITLE
Fixed the eslint errors in solver and added ignore for generated files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/backend/parserlib/Arithmetic*

--- a/src/backend/parserlib/ListenerSolver.js
+++ b/src/backend/parserlib/ListenerSolver.js
@@ -22,6 +22,7 @@ class ListenerSolver extends ArithmeticListener {
         const number = parseInt(ctx.INT(), 10);
         this._stack.push(number);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log("Parsed integer", number);
         }
     }
@@ -34,6 +35,7 @@ class ListenerSolver extends ArithmeticListener {
         const number = -1 * parseInt(ctx.INT(), 10);
         this._stack.push(number);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log("Parsed integer", number);
         }
     }
@@ -46,6 +48,7 @@ class ListenerSolver extends ArithmeticListener {
         const number = parseFloat(ctx.DOUBLE());
         this._stack.push(number);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log("Parsed double", number);
         }
     }
@@ -58,6 +61,7 @@ class ListenerSolver extends ArithmeticListener {
         const number = -1 * parseFloat(ctx.DOUBLE());
         this._stack.push(number);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log("Parsed double", number);
         }
     }
@@ -79,6 +83,7 @@ class ListenerSolver extends ArithmeticListener {
         }
         this._stack.push(result);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log(left, ctx.getChild(1).getText(), right);
         }
     }
@@ -101,6 +106,7 @@ class ListenerSolver extends ArithmeticListener {
 
         this._stack.push(result);
         if (this.DEBUG) {
+            // eslint-disable-next-line no-console
             console.log(left, ctx.getChild(1).getText(), right);
         }
     }


### PR DESCRIPTION
There were around 600 style errors in the code because of my generated files in the parser that we missed. I added the generated files to the ignore. I also fixed the style warnings with the console logs in the solver. I simply suppressed them since the logs only print with debug mode on. (which is VERY useful for figuring the parser issues out) 